### PR TITLE
Do not remove relations from different nodes while saving a HasOne relation

### DIFF
--- a/src/Eloquent/Edges/Relation.php
+++ b/src/Eloquent/Edges/Relation.php
@@ -212,7 +212,7 @@ abstract class Relation extends Delegate
                 $relationshipLabels = $relatedNode->getLabels();
 
                 foreach ($relationshipLabels as $relationshipLabel) {
-                    if (in_array($relationshipLabel->getName(), (array)$this->related->getLabel())) {
+                    if (in_array($relationshipLabel->getName(), (array) $this->related->getLabel())) {
                         $relationship->delete();
                     }
                 }

--- a/src/Eloquent/Edges/Relation.php
+++ b/src/Eloquent/Edges/Relation.php
@@ -204,10 +204,18 @@ abstract class Relation extends Delegate
         */
         if ($this->unique && !$this->exists()) {
             $parent = $this->asNode($this->parent);
-            $existing = $parent->getFirstRelationship((array) $this->type, $this->getRealDirection($this->direction));
+            $realDirection = $this->getRealDirection($this->direction);
+            $relationships = $parent->getRelationships((array) $this->type, $realDirection);
 
-            if (!empty($existing)) {
-                $existing->delete();
+            foreach ($relationships as $relationship) {
+                $relatedNode = $realDirection === 'in' ? $relationship->getStartNode() : $relationship->getEndNode();
+                $relationshipLabels = $relatedNode->getLabels();
+
+                foreach ($relationshipLabels as $relationshipLabel) {
+                    if (in_array($relationshipLabel->getName(), (array)$this->related->getLabel())) {
+                        $relationship->delete();
+                    }
+                }
             }
         }
 

--- a/tests/functional/HasOneRelationTest.php
+++ b/tests/functional/HasOneRelationTest.php
@@ -15,6 +15,16 @@ class User extends Model
     {
         return $this->hasOne('Vinelab\NeoEloquent\Tests\Functional\Relations\HasOne\Profile', 'PROFILE');
     }
+
+    public function dog()
+    {
+        return $this->hasOne('Vinelab\NeoEloquent\Tests\Functional\Relations\HasOne\Dog', 'HAS');
+    }
+
+    public function cat()
+    {
+        return $this->hasOne('Vinelab\NeoEloquent\Tests\Functional\Relations\HasOne\Cat', 'HAS');
+    }
 }
 
 class Profile extends Model
@@ -22,6 +32,20 @@ class Profile extends Model
     protected $label = 'Profile';
 
     protected $fillable = ['guid', 'service'];
+}
+
+class Cat extends Model
+{
+    protected $label = 'Cat';
+
+    protected $fillable = ['name'];
+}
+
+class Dog extends Model
+{
+    protected $label = 'Dog';
+
+    protected $fillable = ['name'];
 }
 
 class HasOneRelationTest extends TestCase
@@ -171,5 +195,32 @@ class HasOneRelationTest extends TestCase
         $this->assertEquals($relation->id, $retrieved->id);
         $this->assertEquals($relation->toArray(), $retrieved->toArray());
         $this->assertTrue($relation->delete());
+    }
+
+    public function testSavingAHasOneRelationDoNotRemoveOtherRelationsFromDifferentNodesThatHasTheSameRelationName()
+    {
+        $user = User::create(['name' => 'Dr. Dolittle']);
+        $dog = Dog::create(['name' => 'Bingo']);
+        $cat = Cat::create(['name' => 'Kitty']);
+
+        $user->dog()->save($dog);
+        $user->cat()->save($cat);
+
+        $resultUser = User::with(['dog', 'cat'])->find($user->id);
+        $this->assertEquals($dog->name, $resultUser->dog->name);
+        $this->assertEquals($cat->name, $resultUser->cat->name);
+    }
+
+    public function testSavingAHasOneRelationRemovesOtherRelationsFromTheSameNode()
+    {
+        $user = User::create(['name' => 'Dr. Dolittle']);
+        $dog1 = Dog::create(['name' => 'Bingo1']);
+        $dog2 = Dog::create(['name' => 'Bingo2']);
+
+        $user->dog()->save($dog1);
+        $user->dog()->save($dog2);
+
+        $resultUser = User::with(['dog', 'cat'])->find($user->id);
+        $this->assertEquals($dog2->name, $resultUser->dog->name);
     }
 }


### PR DESCRIPTION
Before we were removing the first relation with the same name, thus, there is no guarantee that the relation removed is the correct one.